### PR TITLE
python3 compatibility fixes for nim_vios_hc.

### DIFF
--- a/plugins/modules/alt_disk.py
+++ b/plugins/modules/alt_disk.py
@@ -84,7 +84,7 @@ options:
       rootvg has been cloned.
     type: str
 notes:
-  - M(alt_disk) only backs up mounted file systems. Mount all file
+  - M(ibm.power_aix.alt_disk) only backs up mounted file systems. Mount all file
     systems that you want to back up.
   - When no target is specified, copy is performed to only one alternate
     disk even if the rootvg contains multiple disks.

--- a/plugins/modules/backup.py
+++ b/plugins/modules/backup.py
@@ -211,8 +211,8 @@ notes:
     JFS-mounted file system data will be backed up. Raw logical volume data will NOT be backed up
     using a savevg.
   - C(savevg) only backs up varied-on volume group. The file systems must be mounted.
-  - This M(backup) module only operates on LPAR, for operation on VIOS, please checkout the
-    M(backupios) module in the power-vios collection.
+  - This M(ibm.power_aix.backup) module only operates on LPAR, for operation on VIOS, please checkout the
+    M(ibm.power_vios.backupios) module in the power-vios collection.
   - You can refer to the IBM documentation for additional information on the commands used at
     U(U(https://www.ibm.com/support/knowledgecenter/ssw_aix_72/a_commands/alt_disk_mksysb.html),
     U(U(https://www.ibm.com/support/knowledgecenter/ssw_aix_72/l_commands/lsmksysb.html),

--- a/plugins/modules/nim_vios_hc.py
+++ b/plugins/modules/nim_vios_hc.py
@@ -81,6 +81,7 @@ status:
 '''
 
 import re
+import os
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -368,9 +369,8 @@ def vios_health(module, mgmt_sys_uuid, hmc_ip, vios_uuids):
             1 otherwise
     """
     module.debug('hmc_ip: {0} vios_uuids: {1}'.format(hmc_ip, vios_uuids))
-
     # Build the vioshc cmd
-    cmd = [vioshc_cmd, '-i', hmc_ip, '-m', mgmt_sys_uuid]
+    cmd = [vioshc_interpreter, vioshc_cmd, '-i', hmc_ip, '-m', mgmt_sys_uuid]
     for uuid in vios_uuids:
         cmd.extend(['-U', uuid])
     if module._verbosity > 0:
@@ -413,7 +413,7 @@ def vios_health_init(module, hmc_id, hmc_ip):
     module.debug('hmc_id: {0}, hmc_ip: {1}'.format(hmc_id, hmc_ip))
 
     # Call the vioshc.py script a first time to collect UUIDs
-    cmd = [vioshc_cmd, '-i', hmc_ip, '-l', 'a']
+    cmd = [vioshc_interpreter, vioshc_cmd, '-i', hmc_ip, '-l', 'a']
     if module._verbosity > 0:
         cmd.extend(['-' + 'v' * module._verbosity])
         if module._verbosity >= 3:
@@ -596,11 +596,60 @@ def health_check(module, targets):
     return health_tab
 
 
+def get_vioshc_interpreter(module):
+    """
+    Provide the right python interpreter to be used for vioshc command.
+    
+    return: Right python interpreter if ok,
+            Null string otherwise
+    """
+    #Check whether the python interpreter is in the list.
+    #if that path exists on the system , then continue with that
+    #else proceed to the next interpreter in the list.
+    is_interpreter_found = False
+    is_pycurl_found= False
+    python_interpreter_list  = ['/usr/bin/python', '/opt/freeware/bin/python3', '/usr/bin/python3']
+    
+    for interpreter in python_interpreter_list:
+        #Reinitialize these values for every loop
+        is_interpreter_found = False
+        is_pycurl_found= False
+        #check if that path exists. Add check for pycurl module.
+        if os.path.isfile(interpreter):
+            is_interpreter_found = True
+            cmd = interpreter + '  -c "import pycurl"'
+            ret, stdout, stderr = module.run_command(cmd)
+            if ret == 0:
+                return interpreter
+            else:
+                is_pycurl_found = False
+        
+        
+    #If we have exhausted the list, that means no interpreter or no pycurl module
+    # in the list was found. So give a error message.The interpreter will be found
+    #always because without the ansible module will not run anyway.
+    if  is_interpreter_found == True:
+        if is_pycurl_found == False:
+            msg = 'Unable to find the right python interpreter with the dependent module pycurl.'
+            OUTPUT.append('    Warning: Dependent module pycurl is not found  ')
+            results['stdout'] = stdout
+            results['stderr'] = stderr
+    else:
+        msg = 'Unable to find the python interpreter for vioshc command. '
+        OUTPUT.append('    Warning: No python interpreter found. ')
+
+    results['msg'] = msg
+    return None;
+	
+	
+
+
 def main():
     global results
     global OUTPUT
     global NIM_NODE
     global vioshc_cmd
+    global vioshc_interpreter
 
     module = AnsibleModule(
         argument_spec=dict(
@@ -636,9 +685,16 @@ def main():
         OUTPUT.append('    Targets list: {0}'.format(target_list))
         module.debug('Targets list: {0}'.format(target_list))
 
-        # Check vioshc script is present, fail_json if not
+        # Get the interpreter for vioshc command.  If unable to find a
+        # proper interpreter, then fail.
+        vioshc_interpreter = get_vioshc_interpreter(module)
+        if(vioshc_interpreter is None):
+            module.fail_json(**results)
+                   
+        
+        # Get the vioshc command path
         vioshc_cmd = module.get_bin_path('vioshc.py', required=True)
-        module.debug('Using vioshc.py script at {0}'.format(vioshc_cmd))
+        module.debug('Using vioshc.py script at {0}:{1}'.format(vioshc_interpreter, vioshc_cmd))
 
         targets_health_status = health_check(module, target_list)
 

--- a/plugins/modules/nim_vios_hc.py
+++ b/plugins/modules/nim_vios_hc.py
@@ -185,7 +185,7 @@ def get_nim_clients_info(module, lpar_type):
     """
     info_hash = {}
 
-    cmd = ['lsnim', '-t', lpar_type, '-l']
+    cmd = ['/usr/sbin/lsnim', '-t', lpar_type, '-l']
     ret, stdout, stderr = module.run_command(cmd)
     if ret != 0:
         msg = 'Failed to get NIM clients info, lsnim returned: {0}'.format(stderr)
@@ -244,10 +244,10 @@ def build_nim_node(module):
     nim_vios = get_nim_clients_info(module, 'vios')
 
     # Complete the CEC serial in nim_vios dict
-    for key in nim_vios:
-        mgmt_cec = nim_vios[key]['mgmt_cec']
+    for key, nimvios in nim_vios.items():
+        mgmt_cec = nimvios['mgmt_cec']
         if mgmt_cec in nim_cec:
-            nim_vios[key]['mgmt_cec_serial'] = nim_cec[mgmt_cec]['serial']
+            nimvios['mgmt_cec_serial'] = nim_cec[mgmt_cec]['serial']
 
     NIM_NODE['nim_vios'] = nim_vios
     module.debug('NIM VIOS: {0}'.format(nim_vios))
@@ -599,22 +599,23 @@ def health_check(module, targets):
 def get_vioshc_interpreter(module):
     """
     Provide the right python interpreter to be used for vioshc command.
-    
     return: Right python interpreter if ok,
             Null string otherwise
     """
-    #Check whether the python interpreter is in the list.
-    #if that path exists on the system , then continue with that
-    #else proceed to the next interpreter in the list.
+    """
+    Check whether the python interpreter is in the list.
+    if that path exists on the system , then continue with that
+    else proceed to the next interpreter in the list.
+    """
     is_interpreter_found = False
-    is_pycurl_found= False
-    python_interpreter_list  = ['/usr/bin/python', '/opt/freeware/bin/python3', '/usr/bin/python3']
-    
+    is_pycurl_found = False
+    python_interpreter_list = ['/usr/bin/python', '/opt/freeware/bin/python3', '/usr/bin/python3']
+
     for interpreter in python_interpreter_list:
-        #Reinitialize these values for every loop
+        # Reinitialize these values for every loop
         is_interpreter_found = False
-        is_pycurl_found= False
-        #check if that path exists. Add check for pycurl module.
+        is_pycurl_found = False
+        # check if that path exists. Add check for pycurl module.
         if os.path.isfile(interpreter):
             is_interpreter_found = True
             cmd = interpreter + '  -c "import pycurl"'
@@ -623,13 +624,14 @@ def get_vioshc_interpreter(module):
                 return interpreter
             else:
                 is_pycurl_found = False
-        
-        
-    #If we have exhausted the list, that means no interpreter or no pycurl module
-    # in the list was found. So give a error message.The interpreter will be found
-    #always because without the ansible module will not run anyway.
-    if  is_interpreter_found == True:
-        if is_pycurl_found == False:
+
+    """
+    If we have exhausted the list, that means no interpreter or no pycurl module
+    in the list was found. So give a error message.The interpreter will be found
+    always because without the ansible module will not run anyway.
+    """
+    if is_interpreter_found is True:
+        if is_pycurl_found is False:
             msg = 'Unable to find the right python interpreter with the dependent module pycurl.'
             OUTPUT.append('    Warning: Dependent module pycurl is not found  ')
             results['stdout'] = stdout
@@ -639,9 +641,7 @@ def get_vioshc_interpreter(module):
         OUTPUT.append('    Warning: No python interpreter found. ')
 
     results['msg'] = msg
-    return None;
-	
-	
+    return None
 
 
 def main():
@@ -684,14 +684,14 @@ def main():
         target_list = ret
         OUTPUT.append('    Targets list: {0}'.format(target_list))
         module.debug('Targets list: {0}'.format(target_list))
-
-        # Get the interpreter for vioshc command.  If unable to find a
-        # proper interpreter, then fail.
+        """
+        Get the interpreter for vioshc command.  If unable to find a
+        proper interpreter, then fail.
+        """
         vioshc_interpreter = get_vioshc_interpreter(module)
         if(vioshc_interpreter is None):
             module.fail_json(**results)
-                   
-        
+
         # Get the vioshc command path
         vioshc_cmd = module.get_bin_path('vioshc.py', required=True)
         module.debug('Using vioshc.py script at {0}:{1}'.format(vioshc_interpreter, vioshc_cmd))
@@ -700,9 +700,9 @@ def main():
 
         OUTPUT.append('VIOS Health Check status:')
         module.log('VIOS Health Check status:')
-        for vios_key in targets_health_status.keys():
-            OUTPUT.append("    {0} : {1}".format(vios_key, targets_health_status[vios_key]))
-            module.log('    {0} : {1}'.format(vios_key, targets_health_status[vios_key]))
+        for vios_key, vios_health_status in targets_health_status.items():
+            OUTPUT.append("    {0} : {1}".format(vios_key, vios_health_status))
+            module.log('    {0} : {1}'.format(vios_key, vios_health_status))
 
     results['targets'] = target_list
     results['nim_node'] = NIM_NODE

--- a/plugins/modules/nim_vios_hc.py
+++ b/plugins/modules/nim_vios_hc.py
@@ -97,7 +97,7 @@ def get_hmc_info(module):
     """
     info_hash = {}
 
-    cmd = ['lsnim', '-t', 'hmc', '-l']
+    cmd = ['/usr/sbin/lsnim', '-t', 'hmc', '-l']
     ret, stdout, stderr = module.run_command(cmd)
     if ret != 0:
         msg = 'Failed to get HMC NIM info, lsnim returned {0}: {1}'.format(ret, stderr)
@@ -149,7 +149,7 @@ def get_nim_cecs_info(module):
     """
     info_hash = {}
 
-    cmd = ['lsnim', '-t', 'cec', '-l']
+    cmd = ['/usr/sbin/lsnim', '-t', 'cec', '-l']
     ret, stdout, stderr = module.run_command(cmd)
     if ret != 0:
         msg = 'Failed to get CEC NIM info, lsnim returned {0}: {1}'.format(ret, stderr)

--- a/roles/power_aix_vioshc/files/vioshc.py
+++ b/roles/power_aix_vioshc/files/vioshc.py
@@ -282,11 +282,7 @@ def get_nim_name(hostname):
     """
     name = ""
 
-<<<<<<< HEAD
-    cmd = ["/usr/sbin/lsnim", "-a", "if1"]
-=======
-    cmd = ["lsnim", "-a", "if1"]
->>>>>>> c4eaa46f52fe2f9c210205b03bad47d48b747c32
+    cmd = ['/usr/sbin/lsnim', '-a', 'if1']
     (rc, output, errout) = exec_cmd(cmd)
     if rc != 0:
         write('ERROR: Failed to get NIM name for {0}: {1} {2}'

--- a/roles/power_aix_vioshc/files/vioshc.py
+++ b/roles/power_aix_vioshc/files/vioshc.py
@@ -83,7 +83,7 @@ def touch(path):
     """
     log("creating file: {0}\n".format(path))
     try:
-        with open(path, 'a', encoding='utf-8') as file_handle:
+        with open(path, 'a') as file_handle:
             log("file open successful.\n")
     except IOError as e:
         write('ERROR: Failed to create file {0}: {1}.'
@@ -145,7 +145,7 @@ def format_xml_file(filename):
     Output: none
     """
     try:
-        with open(filename, 'r+', encoding="utf-8") as f:
+        with open(filename, 'r+') as f:
             lines = f.readlines()
             f.seek(0)
             start_writing = False
@@ -175,7 +175,7 @@ def exec_cmd(cmd):
     th_id = threading.current_thread().ident
     stderr_file = os.path.join(log_dir, 'cmd_stderr_{0}'.format(th_id))
     try:
-        with open(stderr_file, 'w', encoding='utf-8') as myfile:
+        with open(stderr_file, 'w') as myfile:
             output = subprocess.check_output(cmd, stderr=myfile)
             output = output.decode('UTF-8')
             s = re.search(r'rc=([-\d]+)$', output)
@@ -209,7 +209,7 @@ def exec_cmd(cmd):
 
     # check for error message
     if os.path.getsize(stderr_file) > 0:
-        with open(stderr_file, 'r', encoding='utf-8') as myfile:
+        with open(stderr_file, 'r') as myfile:
             errout += ''.join(myfile)
     os.remove(stderr_file)
 
@@ -361,7 +361,7 @@ def get_usr_passwd(decrypt_file):
     Output:(str) password
     """
     try:
-        with open(decrypt_file, 'r', encoding='utf-8') as f:
+        with open(decrypt_file, 'r') as f:
             arr = f.read().split(' ')
     except IOError as e:
         write("ERROR: Failed to open file {0}: {1}.".format(decrypt_file, e.strerror), lvl=0)
@@ -508,7 +508,7 @@ def get_session_key(hmc_info, filename):
 
     # Reopen the file in text mode
     try:
-        with open(filename, 'r', encoding="utf-8") as f:
+        with open(filename, 'r') as f:
             # Isolate session key
             for line in f:
                 if re.search('<X-API-Session', line):
@@ -826,7 +826,7 @@ def get_vios_sea_state(vios_name, sea_device):
     # file to get all SEA info (debug)
     filename = "{0}/{1}_{2}.txt".format(xml_dir, vios_name, sea_device)
     try:
-        f = open(filename, 'w+', encoding="utf-8")
+        f = open(filename, 'w+')
     except IOError as e:
         write("ERROR: Failed to create file {0}: {1}.".format(filename, e.strerror), lvl=0)
         f = None
@@ -999,7 +999,7 @@ def get_vscsi_mapping(vios_name, vios_uuid):
         write(vscsi_header, lvl=1)
         write(divider, lvl=1)
 
-        msg_txt = open(filename_msg, 'w+', encoding="utf-8")
+        msg_txt = open(filename_msg, 'w+')
 
         for udid, vio_scsi_mapping in vios_scsi_mapping.items():
             write(format_string % (vio_scsi_mapping["BackingDeviceName"],
@@ -1409,7 +1409,7 @@ xml_dir = "%s/xml_dir_%04d_%02d_%d_%02d%02d%02d" \
           % (log_dir, today.year, today.month, today.day, today.hour, today.minute, today.second)
 os.makedirs(xml_dir)
 try:
-    log_file = open(log_path, 'a+', 1, encoding="utf-8")
+    log_file = open(log_path, 'a+', 1)
 except IOError as e:
     print("ERROR: Failed to create log file {0}: {1}.".format(log_path, e.strerror))
     sys.exit(3)

--- a/roles/power_aix_vioshc/files/vioshc.py
+++ b/roles/power_aix_vioshc/files/vioshc.py
@@ -282,7 +282,7 @@ def get_nim_name(hostname):
     """
     name = ""
 
-    cmd = ["lsnim", "-a", "if1"]
+    cmd = ["/usr/sbin/lsnim", "-a", "if1"]
     (rc, output, errout) = exec_cmd(cmd)
     if rc != 0:
         write('ERROR: Failed to get NIM name for {0}: {1} {2}'
@@ -295,11 +295,10 @@ def get_nim_name(hostname):
             name = match.group(1)
             continue
         match = re.match(r'^\s*if1\s*=\s*\S+\s+(\S+).*$', line)
-        if match and match.group(1) != hostname:
-            name = ""
-            continue
-        else:
+        if match and match.group(1) == hostname:
             break
+        name = ""
+
     if name == "":
         write('ERROR: Failed to get NIM name for {0}: Not Found'
               .format(hostname), lvl=0)
@@ -1969,17 +1968,14 @@ if vios_num > 1:
                 write('PASS: SEA(s) deserving VLAN(s) {0} are configured for failover.'
                       .format(vlan_id), lvl=0)
                 num_hc_pass += 1
-                continue
             elif (vios1_state == "LIMBO") and (vios2_state == "LIMBO"):
                 write('PASS: SEA(s) deserving VLAN(s) {0} are configured on both VIOSes but '
                       'not in usable state'.format(vlan_id), lvl=0)
                 num_hc_pass += 1
-                continue
             else:
                 write('FAIL: SEA(s) deserving VLAN(s) {0} are not in the correct state for '
                       'HA operation.'.format(vlan_id), lvl=0)
                 num_hc_fail += 1
-                continue
         elif vios1_state == "LIMBO":
             write('PASS: SEA(s) deserving VLAN(s) {0} are not configured on both VIOSes but '
                   'not in usable state.'.format(vlan_id), lvl=0)
@@ -2001,16 +1997,13 @@ if vios_num > 1:
                 write('PASS: SEA(s) deserving VLAN(s) {0} are not configured on both VIOSes '
                       'but not in usable state.'.format(vlan_id), lvl=0)
                 num_hc_fail += 1
-                continue
             elif vios2_state == "":
                 write('PASS: SEA(s) deserving VLAN(s) {0} are not configured on both VIOSes but '
                       'not in usable state.'.format(vlan_id), lvl=0)
-                continue
             else:
                 write('FAIL: SEA(s) deserving VLAN(s) {0} are not configured on both VIOSes.'
                       .format(vlan_id), lvl=0)
                 num_hc_fail += 1
-                continue
 if len(sea_config[vios1_name].keys()) == 0 \
    and (vios_num == 1 or (vios_num > 1 and len(sea_config[vios2_name].keys()) == 0)):
     write('\nNo SEA Configuration Detected.', lvl=0)

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -35,7 +35,6 @@ plugins/modules/user.py validate-modules:module-invalid-version-added
 plugins/modules/alt_disk.py pylint:consider-using-dict-items
 plugins/modules/nim_updateios.py pylint:consider-using-dict-items
 plugins/modules/nim_vios_alt_disk.py pylint:consider-using-dict-items
-plugins/modules/nim_vios_hc.py pylint:consider-using-dict-items
 plugins/modules/nim_viosupgrade.py pylint:consider-using-dict-items
 plugins/modules/flrtvc.py pylint:consider-using-with
 plugins/modules/nim_flrtvc.py pylint:consider-using-with

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -35,7 +35,6 @@ plugins/modules/user.py validate-modules:module-invalid-version-added
 plugins/modules/alt_disk.py pylint:consider-using-dict-items
 plugins/modules/nim_updateios.py pylint:consider-using-dict-items
 plugins/modules/nim_vios_alt_disk.py pylint:consider-using-dict-items
-plugins/modules/nim_vios_hc.py pylint:consider-using-dict-items
 plugins/modules/nim_viosupgrade.py pylint:consider-using-dict-items
 plugins/modules/flrtvc.py pylint:consider-using-with
 plugins/modules/nim_flrtvc.py pylint:consider-using-with

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,6 +1,4 @@
 plugins/modules/aixpert.py validate-modules:module-invalid-version-added
-plugins/modules/alt_disk.py validate-modules:module-invalid-version-added
-plugins/modules/backup.py validate-modules:module-invalid-version-added
 plugins/modules/bootlist.py validate-modules:module-invalid-version-added
 plugins/modules/devices.py validate-modules:module-invalid-version-added
 plugins/modules/emgr.py validate-modules:module-invalid-version-added
@@ -32,5 +30,7 @@ plugins/modules/reboot.py validate-modules:module-invalid-version-added
 plugins/modules/smtctl.py validate-modules:module-invalid-version-added
 plugins/modules/suma.py validate-modules:module-invalid-version-added
 plugins/modules/user.py validate-modules:module-invalid-version-added
+plugins/modules/alt_disk.py validate-modules:module-invalid-version-added
+plugins/modules/backup.py validate-modules:module-invalid-version-added
 plugins/modules/lvm_facts.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/lpar_facts.py validate-modules:invalid-ansiblemodule-schema

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -5,7 +5,6 @@ roles/power_aix_bootstrap/files/yum_installer.sh shellcheck!skip #helper script
 plugins/modules/alt_disk.py pylint:consider-using-dict-items
 plugins/modules/nim_updateios.py pylint:consider-using-dict-items
 plugins/modules/nim_vios_alt_disk.py pylint:consider-using-dict-items
-plugins/modules/nim_vios_hc.py pylint:consider-using-dict-items
 plugins/modules/nim_viosupgrade.py pylint:consider-using-dict-items
 plugins/modules/flrtvc.py pylint:consider-using-with
 plugins/modules/nim_flrtvc.py pylint:consider-using-with
@@ -69,3 +68,7 @@ plugins/modules/lvg.py pylint:global-variable-not-assigned
 plugins/modules/mount.py pylint:global-variable-not-assigned
 plugins/modules/nim_flrtvc.py pylint:global-variable-not-assigned
 plugins/modules/nim_vios_alt_disk.py pylint:global-variable-not-assigned
+roles/power_aix_vioshc/files/vioshc.py pylint:global-variable-not-assigned
+roles/power_aix_vioshc/files/vioshc.py pylint:consider-using-f-string
+roles/power_aix_vioshc/files/vioshc.py pylint:unspecified-encoding
+roles/power_aix_vioshc/files/vioshc.py pylint:consider-using-with


### PR DESCRIPTION
1. Fixed python3 compatibility issues
2. Pickup right python interpreter for nim_vios_hc module.
nim_vios_hc module invokes a python script vioshc.py which is copied to nim through power_aix_vioshc role.
vioshc.py:
This uses pycurl APIs to gather information of different VIOSes and provide health check information.

Python interpreter may not be present in /usr/bin/python only from AIX 7.3. Hence we check for the python interpreter in the following order:
1. /usr/bin/python
2. /opt/freeware/bin/python3
3. /usr/bin/python3

Since vioshc.py needs pycurl module, this code verifies in the order mentioned above whether pycurl module exists. Whichever python interpreter with pycurl module is discovered first is used to invoke vioshc.py. 

If none of the interpreters have the pycurl module or none of these python interpreters are found, then nim_vios_hc module will exit with appropriate errors.

